### PR TITLE
Regent.parse - Closes #39

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -677,7 +677,6 @@ clothingLogic.find(x => x.rule(data))
 // => { value: ['sandals', 't-shirt'], rule: isWarm }
 ```
 
-
 ### `filter`
 
 `filter(logicArray, data)`
@@ -746,6 +745,130 @@ const clothingLogic = [
 // a function before attempting to call it
 clothingLogic.filter(x => x.rule(data))
 // => [{ value: ['sandals', 't-shirt'], rule: isWarm }, { value: ['umbrella'], rule: isRaining }]
+```
+
+## Parse
+
+`parse(JSONRulesObject)`
+
+The `parse` function parses JSON defined regent rules into functional regent rules. Defining rules as JSON makes it easier to share rule definitions across multiple applications
+
+_*Arguments*_
+
+* `JSONRulesObject (JSON Object)` a JSON object of regent rule definitions
+
+Each top level property name becomes a rule name. Each predicate can be defined with the pattern `<predicateName>: [...args]`.
+
+Composed rules can be defined with the pattern `<compositionPredicateName>: [<predicateName>: [...args], <predicateName>: [...args]]`
+
+_*Returns*_
+
+`Object`: object of functional regent rules
+
+_*Example*_
+
+```javascript
+const json = {
+  "fooAndBar": {
+    "and": [{
+      "equals": ["@foo", "foo"]
+    }, {
+      "equals": ["@bar", "bar"]
+    }]
+  },
+
+  "emptyFoo": {
+    "empty": ["@foo"]
+  },
+
+  "fooEqualsFoo": {
+    "equals": ["@foo", "foo"]
+  },
+
+  "everyRule": {
+    "every": ["@arr", {
+      "equals": ["@__", "foo"]
+    }]
+  },
+
+  "greaterThanOrEqualsRule": {
+    "greaterThanOrEquals": ["@foo", 10]
+  },
+
+  "greaterThanRule": {
+    "greaterThan": ["@foo", 10]
+  },
+
+  "lessThanOrEqualsRule": {
+    "lessThanOrEquals": ["@foo", 10]
+  },
+
+  "lessThanRule": {
+    "lessThan": ["@foo", 10]
+  },
+
+  "noneRule": {
+    "none": [{
+      "equals": ["@foo", "foo"]
+    }, {
+      "equals": ["@bar", "bar"]
+    }]
+  },
+
+  "notRule": {
+    "not": [{
+      "equals": ["@foo", "foo"]
+    }]
+  },
+
+  "orRule": {
+    "or": [{
+      "equals": ["@foo", "foo"]
+    }, {
+      "equals": ["@foo", "bar"]
+    }]
+  },
+
+  "regexRule": {
+    "regex": ["@foo", "^he[l]lo"]
+  },
+
+  "someRule": {
+    "some": ["@arr", {
+      "equals": ["@__", "foo"]
+    }]
+  },
+
+  "typeOfRule": {
+    "typeOf": ["@foo", "string"]
+  },
+
+  "xorRule": {
+    "xor": [{
+      "equals": ["@foo", "foo"]
+    }, {
+      "equals": ["@bar", "bar"]
+    }]
+  }
+}
+
+const {
+  fooAndBar,
+  emptyFoo,
+  fooEqualsFoo,
+  everyRule,
+  greaterThanOrEqualsRule,
+  greaterThanRule,
+  lessThanOrEqualsRule,
+  lessThanRule,
+  noneRule,
+  notRule,
+  orRule,
+  regexRule,
+  someRule,
+  typeOfRule,
+  xorRule
+} = parseFn(json)
 ```
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regent",
-  "version": "3.0.5",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regent",
-  "version": "3.0.5",
+  "version": "3.1.0",
   "description": "Javascript rules engine",
   "repository": {
     "type": "git",

--- a/src/functions/parse.js
+++ b/src/functions/parse.js
@@ -1,0 +1,83 @@
+import and from './and'
+import empty from './empty'
+import equals from './equals'
+import every from './every'
+import greaterThanOrEquals from './greater-than-equals'
+import greaterThan from './greater-than'
+import lessThanOrEquals from './less-than-equals'
+import lessThan from './less-than'
+import none from './none'
+import not from './not'
+import or from './or'
+import regex from './regex'
+import some from './some'
+import typeOf from './type-of'
+import xor from './xor'
+
+export function buildRule (jsonRule) {
+  const predicate = Object.keys(jsonRule)[0]
+  switch (predicate) {
+    case 'empty':
+      return empty(...jsonRule[predicate])
+
+    case 'equals':
+      return equals(...jsonRule[predicate])
+
+    case 'greaterThanOrEquals':
+      return greaterThanOrEquals(...jsonRule[predicate])
+
+    case 'greaterThan':
+      return greaterThan(...jsonRule[predicate])
+
+    case 'lessThanOrEquals':
+      return lessThanOrEquals(...jsonRule[predicate])
+
+    case 'lessThan':
+      return lessThan(...jsonRule[predicate])
+
+    case 'regex':
+      // first argument is a key or literal, second is a string
+      // representing a regex that needs to be parsed
+      return regex(jsonRule[predicate][0], new RegExp(jsonRule[predicate][1]))
+
+    case 'typeOf':
+      return typeOf(...jsonRule[predicate])
+
+    // composed rules
+    case 'and':
+      return and(...jsonRule[predicate].map(x => buildRule(x)))
+
+    case 'every':
+      // first argument is the key, the second is a rule to be built
+      return every(jsonRule[predicate][0], buildRule(jsonRule[predicate][1]))
+
+    case 'none':
+      return none(...jsonRule[predicate].map(x => buildRule(x)))
+
+    case 'not':
+      return not(...jsonRule[predicate].map(x => buildRule(x)))
+
+    case 'or':
+      return or(...jsonRule[predicate].map(x => buildRule(x)))
+
+    case 'some':
+      // first argument is the key, the second is a rule to be built
+      return some(jsonRule[predicate][0], buildRule(jsonRule[predicate][1]))
+
+    case 'xor':
+      return xor(...jsonRule[predicate].map(x => buildRule(x)))
+
+    default:
+      return `${predicate} not found`
+  }
+}
+
+export default (json) => {
+  const result = {}
+  const rules = JSON.parse(json)
+  Object.keys(rules).forEach((key) => {
+    result[key] = buildRule(rules[key])
+  })
+
+  return result
+}

--- a/src/functions/parse.js
+++ b/src/functions/parse.js
@@ -15,7 +15,12 @@ import typeOf from './type-of'
 import xor from './xor'
 
 export function buildRule (jsonRule) {
-  const predicate = Object.keys(jsonRule)[0]
+  // If jsonRule is a string, return it for a more helpful error message
+  // else return the first key
+  const predicate = typeof jsonRule === 'string'
+    ? jsonRule
+    : Object.keys(jsonRule)[0]
+
   switch (predicate) {
     case 'empty':
       return empty(...jsonRule[predicate])
@@ -68,16 +73,22 @@ export function buildRule (jsonRule) {
       return xor(...jsonRule[predicate].map(x => buildRule(x)))
 
     default:
-      return `${predicate} not found`
+      return `${predicate} is not a valid predicate`
   }
 }
 
-export default (json) => {
+export default (json = {}) => {
   const result = {}
-  const rules = JSON.parse(json)
-  Object.keys(rules).forEach((key) => {
-    result[key] = buildRule(rules[key])
-  })
+
+  try {
+    const rules = JSON.parse(json)
+
+    Object.keys(rules).forEach((key) => {
+      result[key] = buildRule(rules[key])
+    })
+  } catch (e) {
+    console.error(`regent.parse ${e}`)
+  }
 
   return result
 }

--- a/src/functions/parse.spec.js
+++ b/src/functions/parse.spec.js
@@ -1,6 +1,6 @@
 import parseFn from './parse'
 
-describe('import', () => {
+describe('parse', () => {
   it('should be a function', () => {
     const actual = typeof parseFn
     const expected = 'function'

--- a/src/functions/parse.spec.js
+++ b/src/functions/parse.spec.js
@@ -1,0 +1,228 @@
+import parseFn from './parse'
+
+describe('import', () => {
+  it('should be a function', () => {
+    const actual = typeof parseFn
+    const expected = 'function'
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should take a json structure and return regent rules', () => {
+    const json = JSON.stringify({
+      isWindy: { greaterThan: ['@windSpeed', 10] },
+      isCold: { lessThan: ['@temp', 65] }
+    })
+
+    const { isWindy, isCold } = parseFn(json)
+    expect(typeof isWindy).toEqual('function')
+    expect(typeof isCold).toEqual('function')
+    expect(isWindy({ windSpeed: 100 })).toEqual(true)
+    expect(isWindy({ windSpeed: 1 })).toEqual(false)
+    expect(isCold({ temp: 100 })).toEqual(false)
+    expect(isCold({ temp: 10 })).toEqual(true)
+  })
+
+  it('should take a json structure of or composed rules', () => {
+    const json = JSON.stringify({
+      windyAndCold: {
+        or: [
+          { greaterThan: ['@windSpeed', 10] },
+          { lessThan: ['@temp', 65] }
+        ]
+      }
+    })
+
+    const { windyAndCold } = parseFn(json)
+    expect(typeof windyAndCold).toEqual('function')
+    expect(windyAndCold({ windSpeed: 100, temp: 100 })).toEqual(true)
+    expect(windyAndCold({ windSpeed: 1, temp: 10 })).toEqual(true)
+    expect(windyAndCold({ windSpeed: 1, temp: 100 })).toEqual(false)
+  })
+
+  it('should take a json structure of and composed rules', () => {
+    const json = JSON.stringify({
+      windyAndCold: {
+        and: [
+          { greaterThan: ['@windSpeed', 10] },
+          { lessThan: ['@temp', 65] }
+        ]
+      }
+    })
+
+    const { windyAndCold } = parseFn(json)
+    expect(typeof windyAndCold).toEqual('function')
+    expect(windyAndCold({ windSpeed: 100, temp: -10 })).toEqual(true) // both cold and windy
+    expect(windyAndCold({ windSpeed: 1, temp: 10 })).toEqual(false) // cold but not windy
+    expect(windyAndCold({ windSpeed: 100, temp: 100 })).toEqual(false) // windy but not cold
+  })
+
+  it('should work with deeply nested compositions', () => {
+    const json = JSON.stringify({
+      deepComposition: {
+        or: [
+          { equals: ['@foo', 'foo'] },
+          {
+            and: [
+              { equals: ['@bar', 'bar'] },
+              { equals: ['@biz', 'biz'] }
+            ]
+          }
+        ]
+      }
+    })
+
+    const { deepComposition } = parseFn(json)
+    expect(typeof deepComposition).toEqual('function')
+    expect(deepComposition({ foo: 'foo' })).toEqual(true)
+    expect(deepComposition({ foo: 'bar' })).toEqual(false)
+    expect(deepComposition({ foo: 'bar', bar: 'bar', biz: 'biz' })).toEqual(true)
+  })
+
+  it('should return null for any rules that do not match a built in predicate', () => {
+    const json = JSON.stringify({
+      customRule: { myCustomPredicate: ['@foo', 17] }
+    })
+
+    const { customRule } = parseFn(json)
+    expect(customRule).toEqual('myCustomPredicate not found')
+  })
+
+  it('should support all native predicates', () => {
+    const json = JSON.stringify({
+      fooAndBar: {
+        and: [
+          { equals: ['@foo', 'foo'] },
+          { equals: ['@bar', 'bar'] }
+        ]
+      },
+      emptyFoo: { empty: ['@foo'] },
+      fooEqualsFoo: { equals: ['@foo', 'foo'] },
+      everyRule: {
+        every: ['@arr', { equals: ['@__', 'foo'] }]
+      },
+      greaterThanOrEqualsRule: { greaterThanOrEquals: ['@foo', 10] },
+      greaterThanRule: { greaterThan: ['@foo', 10] },
+      lessThanOrEqualsRule: { lessThanOrEquals: ['@foo', 10] },
+      lessThanRule: { lessThan: ['@foo', 10] },
+      noneRule: {
+        none: [
+          { equals: ['@foo', 'foo'] },
+          { equals: ['@bar', 'bar'] }
+        ]
+      },
+      notRule: {
+        not: [
+          { equals: ['@foo', 'foo'] }
+        ]
+      },
+      orRule: {
+        or: [
+          { equals: ['@foo', 'foo'] },
+          { equals: ['@foo', 'bar'] }
+        ]
+      },
+      regexRule: {
+        regex: ['@foo', '^he[l]lo']
+      },
+      someRule: {
+        some: ['@arr', { equals: ['@__', 'foo'] }]
+      },
+      typeOfRule: {
+        typeOf: ['@foo', 'string']
+      },
+      xorRule: {
+        xor: [
+          { equals: ['@foo', 'foo'] },
+          { equals: ['@bar', 'bar'] }
+        ]
+      }
+    })
+
+    const {
+      fooAndBar,
+      emptyFoo,
+      fooEqualsFoo,
+      everyRule,
+      greaterThanOrEqualsRule,
+      greaterThanRule,
+      lessThanOrEqualsRule,
+      lessThanRule,
+      noneRule,
+      notRule,
+      orRule,
+      regexRule,
+      someRule,
+      typeOfRule,
+      xorRule
+    } = parseFn(json)
+
+    expect(typeof fooAndBar).toEqual('function')
+    expect(fooAndBar({ foo: 'foo', bar: 'bar' })).toEqual(true)
+    expect(fooAndBar({ foo: 'bar', bar: 'bar' })).toEqual(false)
+
+    expect(typeof emptyFoo).toEqual('function')
+    expect(emptyFoo({ foo: '' })).toEqual(true)
+    expect(emptyFoo({ foo: 'foo' })).toEqual(false)
+
+    expect(typeof fooEqualsFoo).toEqual('function')
+    expect(fooEqualsFoo({ foo: 'foo' })).toEqual(true)
+    expect(fooEqualsFoo({ foo: '' })).toEqual(false)
+
+    expect(typeof everyRule).toEqual('function')
+    expect(everyRule({ arr: ['foo', 'foo'] })).toEqual(true)
+    expect(everyRule({ arr: ['foo', 'bar'] })).toEqual(false)
+
+    expect(typeof greaterThanOrEqualsRule).toEqual('function')
+    expect(greaterThanOrEqualsRule({ foo: 10 })).toEqual(true)
+    expect(greaterThanOrEqualsRule({ foo: 11 })).toEqual(true)
+    expect(greaterThanOrEqualsRule({ foo: 9 })).toEqual(false)
+
+    expect(typeof greaterThanRule).toEqual('function')
+    expect(greaterThanRule({ foo: 10 })).toEqual(false)
+    expect(greaterThanRule({ foo: 11 })).toEqual(true)
+    expect(greaterThanRule({ foo: 9 })).toEqual(false)
+
+    expect(typeof lessThanOrEqualsRule).toEqual('function')
+    expect(lessThanOrEqualsRule({ foo: 10 })).toEqual(true)
+    expect(lessThanOrEqualsRule({ foo: 11 })).toEqual(false)
+    expect(lessThanOrEqualsRule({ foo: 9 })).toEqual(true)
+
+    expect(typeof lessThanRule).toEqual('function')
+    expect(lessThanRule({ foo: 10 })).toEqual(false)
+    expect(lessThanRule({ foo: 11 })).toEqual(false)
+    expect(lessThanRule({ foo: 9 })).toEqual(true)
+
+    expect(typeof noneRule).toEqual('function')
+    expect(noneRule({ foo: 'bar', bar: 'foo' })).toEqual(true)
+    expect(noneRule({ foo: 'bar', bar: 'bar' })).toEqual(false)
+
+    expect(typeof notRule).toEqual('function')
+    expect(notRule({ foo: 'bar' })).toEqual(true)
+    expect(notRule({ foo: 'foo' })).toEqual(false)
+
+    expect(typeof orRule).toEqual('function')
+    expect(orRule({ foo: 'bar' })).toEqual(true)
+    expect(orRule({ foo: 'foo' })).toEqual(true)
+    expect(orRule({ foo: 'baz' })).toEqual(false)
+
+    expect(typeof regexRule).toEqual('function')
+    expect(regexRule({ foo: 'hello' })).toEqual(true)
+    expect(regexRule({ foo: 'hello world' })).toEqual(true)
+    expect(regexRule({ foo: 'world hello' })).toEqual(false) // match not at start of string
+
+    expect(typeof someRule).toEqual('function')
+    expect(someRule({ arr: ['foo', 'bar'] })).toEqual(true)
+    expect(someRule({ arr: ['bar', 'bar'] })).toEqual(false)
+
+    expect(typeof typeOfRule).toEqual('function')
+    expect(typeOfRule({ foo: 'hello' })).toEqual(true)
+    expect(typeOfRule({ foo: 12 })).toEqual(false)
+
+    expect(typeof xorRule).toEqual('function')
+    expect(xorRule({ foo: 'foo', bar: 'foo' })).toEqual(true)
+    expect(xorRule({ foo: 'bar', bar: 'bar' })).toEqual(true)
+    expect(xorRule({ foo: 'bar', bar: 'foo' })).toEqual(false)
+    expect(xorRule({ foo: 'foo', bar: 'bar' })).toEqual(false)
+  })
+})

--- a/src/regent.js
+++ b/src/regent.js
@@ -6,6 +6,7 @@ import filterFn from './functions/filter'
 import findFn from './functions/find'
 import greaterThanOrEqualsFn from './functions/greater-than-equals'
 import greaterThanFn from './functions/greater-than'
+import parseFn from './functions/parse'
 import lessThanOrEqualsFn from './functions/less-than-equals'
 import lessThanFn from './functions/less-than'
 import makeFn from './functions/make'
@@ -25,6 +26,7 @@ export const filter = filterFn
 export const find = findFn
 export const greaterThanOrEquals = greaterThanOrEqualsFn
 export const greaterThan = greaterThanFn
+export const parse = parseFn
 export const lessThanOrEquals = lessThanOrEqualsFn
 export const lessThan = lessThanFn
 export const make = makeFn

--- a/src/regent.spec.js
+++ b/src/regent.spec.js
@@ -13,6 +13,7 @@ import {
   none,
   not,
   or,
+  parse,
   regex,
   some,
   typeOf,
@@ -35,6 +36,7 @@ describe('regent', () => {
     expect(typeof none).toEqual('function')
     expect(typeof not).toEqual('function')
     expect(typeof or).toEqual('function')
+    expect(typeof parse).toEqual('function')
     expect(typeof regex).toEqual('function')
     expect(typeof some).toEqual('function')
     expect(typeof typeOf).toEqual('function')


### PR DESCRIPTION
Add regent.parse to parse JSON rules syntax

Here is a sample of the JSON syntax.

```javascript
const json = JSON.stringify({
      fooAndBar: {
        and: [
          { equals: ['@foo', 'foo'] },
          { equals: ['@bar', 'bar'] }
        ]
      },
      emptyFoo: { empty: ['@foo'] },
      fooEqualsFoo: { equals: ['@foo', 'foo'] },
      everyRule: {
        every: ['@arr', { equals: ['@__', 'foo'] }]
      },
      greaterThanOrEqualsRule: { greaterThanOrEquals: ['@foo', 10] },
      greaterThanRule: { greaterThan: ['@foo', 10] },
      lessThanOrEqualsRule: { lessThanOrEquals: ['@foo', 10] },
      lessThanRule: { lessThan: ['@foo', 10] },
      noneRule: {
        none: [
          { equals: ['@foo', 'foo'] },
          { equals: ['@bar', 'bar'] }
        ]
      },
      notRule: {
        not: [
          { equals: ['@foo', 'foo'] }
        ]
      },
      orRule: {
        or: [
          { equals: ['@foo', 'foo'] },
          { equals: ['@foo', 'bar'] }
        ]
      },
      regexRule: {
        regex: ['@foo', '^he[l]lo']
      },
      someRule: {
        some: ['@arr', { equals: ['@__', 'foo'] }]
      },
      typeOfRule: {
        typeOf: ['@foo', 'string']
      },
      xorRule: {
        xor: [
          { equals: ['@foo', 'foo'] },
          { equals: ['@bar', 'bar'] }
        ]
      }
    })
```