### PR TITLE
Add the toJson feature to export rule definitions as JSON

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -871,6 +871,41 @@ const {
 } = parseFn(json)
 ```
 
+## Utilities
+
+### toJson
+
+`Rule.toJson()`
+
+The `toJson` utility can be used to export rule definitions to JSON. This utility is handy if your rules are all defined as functions and you want to transport the rules into another system, application, or store in a database.
+
+_*Arguments*_
+
+_none_
+
+_*Returns*_
+
+* `JSONRulesObject (JSON Object)` a JSON object of regent rule definitions
+
+_*Example*_
+
+```javascript
+const isRaining = equals('@isRaining', true);
+const isCalm = lessThan('@windSpeedInMph', 25);
+const isRainingAndCalm = and(isRaining, isCalm);
+
+const isRainingJson = isRaining.toJson()
+// { "equals": ["isRaining", true] }
+
+const isRainingAndCalmJson = isRainingAndCalm.toJson()
+// {
+//   "and": [
+//     { "equals": ["@isRaining", true] },
+//     { "lessThan": ["@windSpeedInMph", 25] }
+//   ]
+// }
+```
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regent",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Javascript rules engine",
   "repository": {
     "type": "git",

--- a/src/functions/and.js
+++ b/src/functions/and.js
@@ -1,5 +1,6 @@
 import isRule from '../private/is-rule'
 import evaluateRule from '../private/evaluate-rule'
+import attachToJson from '../private/attach-to-json'
 
 export default (...rules) => {
   // throw if one or more of the rules are
@@ -8,5 +9,7 @@ export default (...rules) => {
     throw new Error('Regent: and requires all arguments to be a function')
   }
 
-  return data => rules.every(x => evaluateRule(x, data))
+  return attachToJson(function and (data) {
+    return rules.every(x => evaluateRule(x, data))
+  }, rules)
 }

--- a/src/functions/and.spec.js
+++ b/src/functions/and.spec.js
@@ -63,4 +63,21 @@ describe('and', () => {
 
     expect(() => and(A, B)(data)).toThrow('Regent: and requires all arguments to be a function')
   })
+
+  it('when the toJson method is called it should return a json representation of the rule.', () => {
+    const A = equals('@foo', 'a')
+    const B = equals('@bar', 'b')
+
+    const MY_RULE = and(A, B)
+
+    const actual = MY_RULE.toJson()
+    const expected = JSON.stringify({
+      and: [
+        { equals: ['@foo', 'a'] },
+        { equals: ['@bar', 'b'] }
+      ]
+    })
+
+    expect(actual).toEqual(expected)
+  })
 })

--- a/src/functions/empty.js
+++ b/src/functions/empty.js
@@ -1,10 +1,10 @@
 import make from './make'
 
-export const emptyFn = input => (
+export const empty = input => (
   input === undefined ||
   input === null ||
   input === 'undefined' ||
   input === ''
 )
 
-export default make(emptyFn)
+export default make(empty)

--- a/src/functions/empty.spec.js
+++ b/src/functions/empty.spec.js
@@ -1,24 +1,24 @@
-import empty, { emptyFn } from './empty'
+import emptyFn, { empty } from './empty'
 
-describe('3.x.x - empty functional style', () => {
+describe('3.x.x - emptyFn functional style', () => {
   it('should be a function', () => {
-    const actual = typeof empty
+    const actual = typeof emptyFn
     const expected = 'function'
 
     expect(actual).toEqual(expected)
   })
 
-  it('should return true for empty items', () => {
+  it('should return true for emptyFn items', () => {
     const data = {
       foo: '',
       bar: null,
       biz: 'undefined'
     }
 
-    const RULE = empty('@foo')(data)
-    const RULE2 = empty('@bar')(data)
-    const RULE3 = empty('@biz')(data)
-    const RULE4 = empty('@baz')(data)
+    const RULE = emptyFn('@foo')(data)
+    const RULE2 = emptyFn('@bar')(data)
+    const RULE3 = emptyFn('@biz')(data)
+    const RULE4 = emptyFn('@baz')(data)
 
     expect(RULE).toEqual(true)
     expect(RULE2).toEqual(true)
@@ -27,12 +27,12 @@ describe('3.x.x - empty functional style', () => {
   })
 })
 
-describe('emptyFn', () => {
-  it('emptyFn should be a function', () => {
-    expect(typeof emptyFn).toEqual('function')
+describe('empty', () => {
+  it('empty should be a function', () => {
+    expect(typeof empty).toEqual('function')
   })
 
-  it('emptyFn should return true if input is undefined, null, "undefined", or "" (emptyFn string)', () => {
+  it('empty should return true if input is undefined, null, "undefined", or "" (empty string)', () => {
     const greenArr = [
       undefined,
       null,
@@ -40,28 +40,28 @@ describe('emptyFn', () => {
       ''
     ]
     greenArr.forEach((input) => {
-      const actual = emptyFn(input)
+      const actual = empty(input)
       const expected = true
       expect(actual).toEqual(expected)
     })
   })
 
   it('validate documentation cases', () => {
-    let result = emptyFn() // true
+    let result = empty() // true
     expect(result).toEqual(true)
-    result = emptyFn('') // true
+    result = empty('') // true
     expect(result).toEqual(true)
-    result = emptyFn(null) // true
+    result = empty(null) // true
     expect(result).toEqual(true)
-    result = emptyFn(undefined) // true
+    result = empty(undefined) // true
     expect(result).toEqual(true)
-    result = emptyFn('some value') // false
+    result = empty('some value') // false
     expect(result).toEqual(false)
-    result = emptyFn({}) // false
+    result = empty({}) // false
     expect(result).toEqual(false)
-    result = emptyFn([]) // false
+    result = empty([]) // false
     expect(result).toEqual(false)
-    result = emptyFn(['']) // false
+    result = empty(['']) // false
     expect(result).toEqual(false)
   })
 })

--- a/src/functions/empty.spec.js
+++ b/src/functions/empty.spec.js
@@ -64,4 +64,12 @@ describe('empty', () => {
     result = empty(['']) // false
     expect(result).toEqual(false)
   })
+
+  it('when the toJson method is called it should return a json representation of the rule.', () => {
+    const MY_RULE = emptyFn('@foo')
+    const actual = MY_RULE.toJson()
+    const expected = JSON.stringify({ empty: ['@foo'] })
+
+    expect(actual).toEqual(expected)
+  })
 })

--- a/src/functions/equals.js
+++ b/src/functions/equals.js
@@ -1,5 +1,5 @@
 import make from './make'
 
-export const equalsFn = (left, right) => left === right
+export const equals = (left, right) => left === right
 
-export default make(equalsFn)
+export default make(equals)

--- a/src/functions/equals.spec.js
+++ b/src/functions/equals.spec.js
@@ -1,30 +1,30 @@
-import equals, { equalsFn } from './equals'
+import equalsFn, { equals } from './equals'
 
-describe('equalsFn', () => {
-  it('equalsFn should be a function', () => {
-    expect(typeof equalsFn).toEqual('function')
+describe('equals', () => {
+  it('equals should be a function', () => {
+    expect(typeof equals).toEqual('function')
   })
 
-  it('equalsFn should return true if the left is in all of the arguments', () => {
+  it('equals should return true if the left is in all of the arguments', () => {
     const left = 'hello'
     const right = 'hello'
-    const acutal = equalsFn(left, right)
+    const acutal = equals(left, right)
     const expected = true
     expect(acutal).toEqual(expected)
   })
 
-  it('equalsFn should return false if left does not match all of the arguments', () => {
+  it('equals should return false if left does not match all of the arguments', () => {
     const left = 'hello'
     const right = 'world'
-    const acutal = equalsFn(left, right)
+    const acutal = equals(left, right)
     const expected = false
     expect(acutal).toEqual(expected)
   })
 })
 
-describe('equals', () => {
+describe('equalsFn', () => {
   it('should be a function', () => {
-    const actual = typeof equals
+    const actual = typeof equalsFn
     const expected = 'function'
 
     expect(actual).toEqual(expected)
@@ -34,7 +34,7 @@ describe('equals', () => {
     const data = {
       foo: 'bar'
     }
-    const actual = equals('@foo', 'bar')(data)
+    const actual = equalsFn('@foo', 'bar')(data)
     const expected = true
 
     expect(actual).toEqual(expected)
@@ -44,7 +44,7 @@ describe('equals', () => {
     const data = {
       foo: 'baz'
     }
-    const actual = equals('@foo', 'bar')(data)
+    const actual = equalsFn('@foo', 'bar')(data)
     const expected = false
 
     expect(actual).toEqual(expected)
@@ -56,7 +56,7 @@ describe('equals', () => {
         { bar: 'bar' }
       ]
     }
-    const actual = equals('@foo[0].bar', 'bar')(data)
+    const actual = equalsFn('@foo[0].bar', 'bar')(data)
     const expected = true
 
     expect(actual).toEqual(expected)
@@ -76,7 +76,7 @@ describe('equals', () => {
 
     const expected = false
     redArr.forEach((x) => {
-      actual = equals('@foo[0].bar', 'bar')(x)
+      actual = equalsFn('@foo[0].bar', 'bar')(x)
       expect(actual).toEqual(expected)
     })
   })

--- a/src/functions/equals.spec.js
+++ b/src/functions/equals.spec.js
@@ -80,4 +80,12 @@ describe('equalsFn', () => {
       expect(actual).toEqual(expected)
     })
   })
+
+  it('when the toJson method is called it should return a json representation of the rule.', () => {
+    const MY_RULE = equalsFn('@foo', 'a')
+    const actual = MY_RULE.toJson()
+    const expected = JSON.stringify({ equals: ['@foo', 'a'] })
+
+    expect(actual).toEqual(expected)
+  })
 })

--- a/src/functions/every.js
+++ b/src/functions/every.js
@@ -2,7 +2,7 @@ import isRule from '../private/is-rule'
 import evaluateRule from '../private/evaluate-rule'
 import makeWithContext from '../private/make-with-context'
 
-export const everyFn = (left, right, context, data) => {
+export const every = (left, right, context, data) => {
   if (!isRule(right)) {
     throw new Error('Regent: the right property of an every rule must be a regent rule')
   }
@@ -14,4 +14,4 @@ export const everyFn = (left, right, context, data) => {
   return left.every(x => evaluateRule(right, { ...data, [context]: x }))
 }
 
-export default makeWithContext(everyFn)
+export default makeWithContext(every)

--- a/src/functions/every.spec.js
+++ b/src/functions/every.spec.js
@@ -1,4 +1,4 @@
-import every from './every'
+import everyFn from './every'
 import equals from '../functions/equals'
 
 describe('3.x.x - every', () => {
@@ -11,7 +11,7 @@ describe('3.x.x - every', () => {
     }
 
     const RULE = equals('@__.foo', 'bar')
-    const E_RULE = every('@nodes', RULE)
+    const E_RULE = everyFn('@nodes', RULE)
     const actual = E_RULE(data)
     const expected = true
 
@@ -27,7 +27,7 @@ describe('3.x.x - every', () => {
     }
 
     const RULE = true
-    const E_RULE = every('@nodes', RULE)
+    const E_RULE = everyFn('@nodes', RULE)
     const actual = E_RULE(data)
     const expected = true
 
@@ -43,7 +43,7 @@ describe('3.x.x - every', () => {
     }
 
     const RULE = false
-    const E_RULE = every('@nodes', RULE)
+    const E_RULE = everyFn('@nodes', RULE)
     const actual = E_RULE(data)
     const expected = false
 
@@ -59,7 +59,7 @@ describe('3.x.x - every', () => {
     }
 
     const RULE = equals('@context.foo', 'bar')
-    const E_RULE = every('@nodes', RULE, 'context')
+    const E_RULE = everyFn('@nodes', RULE, 'context')
     const actual = E_RULE(data)
     const expected = true
 
@@ -75,21 +75,21 @@ describe('3.x.x - every', () => {
     }
 
     const RULE = equals('@__.foo', 'bar')
-    const E_RULE = every('@nodes', RULE)
+    const E_RULE = everyFn('@nodes', RULE)
     const actual = E_RULE(data)
     const expected = false
 
     expect(actual).toEqual(expected)
   })
 
-  it('every should throw an error if right is not a regent rule', () => {
+  it('everyFn should throw an error if right is not a regent rule', () => {
     const right = { something: 'not a rule' }
-    expect(() => every('@nodes', right)({})).toThrow('Regent: the right property of an every rule must be a regent rule')
+    expect(() => everyFn('@nodes', right)({})).toThrow('Regent: the right property of an every rule must be a regent rule')
   })
 
-  it('every should throw an error if right is not a regent rule', () => {
+  it('everyFn should throw an error if right is not a regent rule', () => {
     const right = { something: 'not a rule' }
-    expect(() => every('@nodes', right)({})).toThrow('Regent: the right property of an every rule must be a regent rule')
+    expect(() => everyFn('@nodes', right)({})).toThrow('Regent: the right property of an every rule must be a regent rule')
   })
 
   it('should return false if the first argument is not an array', () => {
@@ -98,9 +98,22 @@ describe('3.x.x - every', () => {
     }
 
     const RULE = equals('@__.foo', 'bar')
-    const E_RULE = every('@nodes', RULE)
+    const E_RULE = everyFn('@nodes', RULE)
     const actual = E_RULE(data)
     const expected = false
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('when it\'s toJson method is called it should return a json representation of the rule', () => {
+    const RULE = equals('@__.foo', 'bar')
+    const E_RULE = everyFn('@nodes', RULE)
+    const actual = E_RULE.toJson()
+    const expected = JSON.stringify({
+      every: ['@nodes',
+        { equals: ['@__.foo', 'bar'] }
+      ]
+    })
 
     expect(actual).toEqual(expected)
   })

--- a/src/functions/greater-than-equals.js
+++ b/src/functions/greater-than-equals.js
@@ -1,5 +1,5 @@
 import make from './make'
 
-export const greaterThanOrEqualsFn = (left, right) => left >= right
+export const greaterThanOrEquals = (left, right) => left >= right
 
-export default make(greaterThanOrEqualsFn)
+export default make(greaterThanOrEquals)

--- a/src/functions/greater-than-equals.spec.js
+++ b/src/functions/greater-than-equals.spec.js
@@ -116,5 +116,13 @@ describe('greaterThanOrEqualsFn', () => {
 
       expect(actual).toEqual(expected)
     })
+
+    it('when the toJson method is called it should return a json representation of the rule.', () => {
+      const MY_RULE = greaterThanOrEqualsFn('@foo', 5)
+      const actual = MY_RULE.toJson()
+      const expected = JSON.stringify({ greaterThanOrEquals: ['@foo', 5] })
+
+      expect(actual).toEqual(expected)
+    })
   })
 })

--- a/src/functions/greater-than-equals.spec.js
+++ b/src/functions/greater-than-equals.spec.js
@@ -1,67 +1,67 @@
-import greaterThanOrEquals, { greaterThanOrEqualsFn } from './greater-than-equals'
+import greaterThanOrEqualsFn, { greaterThanOrEquals } from './greater-than-equals'
 
-describe('greaterThanOrEquals', () => {
-  it('greaterThanOrEquals should be a function', () => {
-    expect(typeof greaterThanOrEqualsFn).toEqual('function')
+describe('greaterThanOrEqualsFn', () => {
+  it('greaterThanOrEqualsFn should be a function', () => {
+    expect(typeof greaterThanOrEquals).toEqual('function')
   })
 
   it('greaterThan should return true if the value given is greater than the param', () => {
-    let actual = greaterThanOrEqualsFn(1, 0)
+    let actual = greaterThanOrEquals(1, 0)
     let expected = true
     expect(actual).toEqual(expected)
 
-    actual = greaterThanOrEqualsFn(4, 3)
+    actual = greaterThanOrEquals(4, 3)
     expected = true
     expect(actual).toEqual(expected)
 
-    actual = greaterThanOrEqualsFn(4.2, 4.1)
+    actual = greaterThanOrEquals(4.2, 4.1)
     expected = true
     expect(actual).toEqual(expected)
 
-    actual = greaterThanOrEqualsFn(4, 4)
+    actual = greaterThanOrEquals(4, 4)
     expected = true
     expect(actual).toEqual(expected)
 
-    actual = greaterThanOrEqualsFn(4.2, 4.2)
+    actual = greaterThanOrEquals(4.2, 4.2)
     expected = true
     expect(actual).toEqual(expected)
   })
 
   it('greaterThan should return true if the value given is equal to the param', () => {
-    let actual = greaterThanOrEqualsFn(1, 1)
+    let actual = greaterThanOrEquals(1, 1)
     let expected = true
     expect(actual).toEqual(expected)
 
-    actual = greaterThanOrEqualsFn(4, 4)
+    actual = greaterThanOrEquals(4, 4)
     expected = true
     expect(actual).toEqual(expected)
 
-    actual = greaterThanOrEqualsFn(4.2, 4.2)
+    actual = greaterThanOrEquals(4.2, 4.2)
     expected = true
     expect(actual).toEqual(expected)
   })
 
-  it('greaterThanOrEqualsFn should return false if the value given is less than the param', () => {
-    let actual = greaterThanOrEqualsFn(1, 2)
+  it('greaterThanOrEquals should return false if the value given is less than the param', () => {
+    let actual = greaterThanOrEquals(1, 2)
     let expected = false
     expect(actual).toEqual(expected)
 
-    actual = greaterThanOrEqualsFn(0, 10)
+    actual = greaterThanOrEquals(0, 10)
     expected = false
     expect(actual).toEqual(expected)
 
-    actual = greaterThanOrEqualsFn(null, 4)
+    actual = greaterThanOrEquals(null, 4)
     expected = false
     expect(actual).toEqual(expected)
   })
 
-  it('greaterThanOrEqualsFn should return false if the key is undefined', () => {
-    const actual = greaterThanOrEqualsFn(undefined, 0)
+  it('greaterThanOrEquals should return false if the key is undefined', () => {
+    const actual = greaterThanOrEquals(undefined, 0)
     const expected = false
     expect(actual).toEqual(expected)
   })
 
-  it('greaterThanOrEqualsFn should return false if the key is a string that parses to NaN', () => {
+  it('greaterThanOrEquals should return false if the key is a string that parses to NaN', () => {
     const redProps = [
       'cool',
       'some string',
@@ -71,27 +71,27 @@ describe('greaterThanOrEquals', () => {
       'true'
     ]
     redProps.forEach((val) => {
-      const actual = greaterThanOrEqualsFn(val, 0)
+      const actual = greaterThanOrEquals(val, 0)
       const expected = false
       expect(actual).toEqual(expected)
     })
   })
 
-  it('greaterThanOrEqualsFn should compare strings based on standard lexicographical ordering, using Unicode values', () => {
-    expect(greaterThanOrEqualsFn('a', 'b')).toEqual(false)
-    expect(greaterThanOrEqualsFn('aaaa', 'abaa')).toEqual(false)
-    expect(greaterThanOrEqualsFn('bb', 'a')).toEqual(true)
-    expect(greaterThanOrEqualsFn('baa', 'abb')).toEqual(true)
-    expect(greaterThanOrEqualsFn('1', 2)).toEqual(false)
-    expect(greaterThanOrEqualsFn('2', 1)).toEqual(true)
-    expect(greaterThanOrEqualsFn('2', '4')).toEqual(false)
-    expect(greaterThanOrEqualsFn('2', '2')).toEqual(true)
-    expect(greaterThanOrEqualsFn(4, 4)).toEqual(true)
+  it('greaterThanOrEquals should compare strings based on standard lexicographical ordering, using Unicode values', () => {
+    expect(greaterThanOrEquals('a', 'b')).toEqual(false)
+    expect(greaterThanOrEquals('aaaa', 'abaa')).toEqual(false)
+    expect(greaterThanOrEquals('bb', 'a')).toEqual(true)
+    expect(greaterThanOrEquals('baa', 'abb')).toEqual(true)
+    expect(greaterThanOrEquals('1', 2)).toEqual(false)
+    expect(greaterThanOrEquals('2', 1)).toEqual(true)
+    expect(greaterThanOrEquals('2', '4')).toEqual(false)
+    expect(greaterThanOrEquals('2', '2')).toEqual(true)
+    expect(greaterThanOrEquals(4, 4)).toEqual(true)
   })
 
-  describe('greaterThanOrEquals', () => {
+  describe('greaterThanOrEqualsFn', () => {
     it('should be a function', () => {
-      const actual = typeof greaterThanOrEquals
+      const actual = typeof greaterThanOrEqualsFn
       const expected = 'function'
 
       expect(actual).toEqual(expected)
@@ -101,7 +101,7 @@ describe('greaterThanOrEquals', () => {
       const data = {
         foo: 5
       }
-      const actual = greaterThanOrEquals('@foo', 3)(data)
+      const actual = greaterThanOrEqualsFn('@foo', 3)(data)
       const expected = true
 
       expect(actual).toEqual(expected)
@@ -111,7 +111,7 @@ describe('greaterThanOrEquals', () => {
       const data = {
         foo: 2
       }
-      const actual = greaterThanOrEquals('@foo', 3)(data)
+      const actual = greaterThanOrEqualsFn('@foo', 3)(data)
       const expected = false
 
       expect(actual).toEqual(expected)

--- a/src/functions/greater-than.js
+++ b/src/functions/greater-than.js
@@ -1,5 +1,5 @@
 import make from './make'
 
-export const greaterThanFn = (left, right) => left > right
+export const greaterThan = (left, right) => left > right
 
-export default make(greaterThanFn)
+export default make(greaterThan)

--- a/src/functions/greater-than.spec.js
+++ b/src/functions/greater-than.spec.js
@@ -1,19 +1,19 @@
-import greaterThan, { greaterThanFn } from './greater-than'
+import greaterThanFn, { greaterThan } from './greater-than'
 
-describe('3.x.x - greaterThan should work in functional style', () => {
+describe('3.x.x - greaterThanFn should work in functional style', () => {
   it('should be a function', () => {
-    const actual = typeof greaterThan
+    const actual = typeof greaterThanFn
     const expected = 'function'
 
     expect(actual).toEqual(expected)
   })
 
-  it('should evaluate greaterThan', () => {
+  it('should evaluate greaterThanFn', () => {
     const data = {
       foo: 3
     }
 
-    const RULE = greaterThan('@foo', 1)
+    const RULE = greaterThanFn('@foo', 1)
     const actual = RULE(data)
     const expected = true
 
@@ -21,58 +21,58 @@ describe('3.x.x - greaterThan should work in functional style', () => {
   })
 })
 
-describe('greaterThanFn', () => {
-  it('greaterThanFn should be a function', () => {
-    expect(typeof greaterThanFn).toEqual('function')
+describe('greaterThan', () => {
+  it('greaterThan should be a function', () => {
+    expect(typeof greaterThan).toEqual('function')
   })
 
-  it('greaterThanFn should return true if the value given is greater than the param', () => {
-    let actual = greaterThanFn(1, 0)
+  it('greaterThan should return true if the value given is greater than the param', () => {
+    let actual = greaterThan(1, 0)
     let expected = true
     expect(actual).toEqual(expected)
 
-    actual = greaterThanFn(4, 3)
+    actual = greaterThan(4, 3)
     expected = true
     expect(actual).toEqual(expected)
 
-    actual = greaterThanFn(4.2, 4.1)
+    actual = greaterThan(4.2, 4.1)
     expected = true
     expect(actual).toEqual(expected)
   })
 
-  it('greaterThanFn should return false if the value given is less than or equal than the param', () => {
-    let actual = greaterThanFn(1, 2)
+  it('greaterThan should return false if the value given is less than or equal than the param', () => {
+    let actual = greaterThan(1, 2)
     let expected = false
     expect(actual).toEqual(expected)
 
-    actual = greaterThanFn(0, 10)
+    actual = greaterThan(0, 10)
     expected = false
     expect(actual).toEqual(expected)
 
-    actual = greaterThanFn(null, 4)
+    actual = greaterThan(null, 4)
     expected = false
     expect(actual).toEqual(expected)
 
-    actual = greaterThanFn(4, 4)
+    actual = greaterThan(4, 4)
     expected = false
     expect(actual).toEqual(expected)
   })
 
-  it('greaterThanFn should return false if the key is undefined', () => {
-    const actual = greaterThanFn(undefined, 0)
+  it('greaterThan should return false if the key is undefined', () => {
+    const actual = greaterThan(undefined, 0)
     const expected = false
     expect(actual).toEqual(expected)
   })
 
-  it('greaterThanFn should return true for documentation cases', () => {
-    let result = greaterThanFn(4, 1) // true
+  it('greaterThan should return true for documentation cases', () => {
+    let result = greaterThan(4, 1) // true
     expect(result).toEqual(true)
 
-    result = greaterThanFn(4, 5) // false
+    result = greaterThan(4, 5) // false
     expect(result).toEqual(false)
   })
 
-  it('greaterThanFn should return false if the key is a string that parses to NaN', () => {
+  it('greaterThan should return false if the key is a string that parses to NaN', () => {
     const redProps = [
       'cool',
       'some string',
@@ -82,19 +82,19 @@ describe('greaterThanFn', () => {
       'true'
     ]
     redProps.forEach((val) => {
-      const actual = greaterThanFn(val, 0)
+      const actual = greaterThan(val, 0)
       const expected = false
       expect(actual).toEqual(expected)
     })
   })
 
-  it('greaterThanFn should compare strings based on standard lexicographical ordering, using Unicode values', () => {
-    expect(greaterThanFn('a', 'b')).toEqual(false)
-    expect(greaterThanFn('aaaa', 'abaa')).toEqual(false)
-    expect(greaterThanFn('bb', 'a')).toEqual(true)
-    expect(greaterThanFn('baa', 'abb')).toEqual(true)
-    expect(greaterThanFn('1', 2)).toEqual(false)
-    expect(greaterThanFn('2', 1)).toEqual(true)
-    expect(greaterThanFn('2', '4')).toEqual(false)
+  it('greaterThan should compare strings based on standard lexicographical ordering, using Unicode values', () => {
+    expect(greaterThan('a', 'b')).toEqual(false)
+    expect(greaterThan('aaaa', 'abaa')).toEqual(false)
+    expect(greaterThan('bb', 'a')).toEqual(true)
+    expect(greaterThan('baa', 'abb')).toEqual(true)
+    expect(greaterThan('1', 2)).toEqual(false)
+    expect(greaterThan('2', 1)).toEqual(true)
+    expect(greaterThan('2', '4')).toEqual(false)
   })
 })

--- a/src/functions/greater-than.spec.js
+++ b/src/functions/greater-than.spec.js
@@ -97,4 +97,12 @@ describe('greaterThan', () => {
     expect(greaterThan('2', 1)).toEqual(true)
     expect(greaterThan('2', '4')).toEqual(false)
   })
+
+  it('when the toJson method is called it should return a json representation of the rule.', () => {
+    const MY_RULE = greaterThanFn('@foo', 5)
+    const actual = MY_RULE.toJson()
+    const expected = JSON.stringify({ greaterThan: ['@foo', 5] })
+
+    expect(actual).toEqual(expected)
+  })
 })

--- a/src/functions/less-than-equals.js
+++ b/src/functions/less-than-equals.js
@@ -1,4 +1,4 @@
 import make from './make'
 
-export const lessThanOrEqualsFn = (left, right) => left <= right
-export default make(lessThanOrEqualsFn)
+export const lessThanOrEquals = (left, right) => left <= right
+export default make(lessThanOrEquals)

--- a/src/functions/less-than-equals.spec.js
+++ b/src/functions/less-than-equals.spec.js
@@ -1,19 +1,19 @@
-import lessThanOrEquals, { lessThanOrEqualsFn } from './less-than-equals'
+import lessThanOrEqualsFn, { lessThanOrEquals } from './less-than-equals'
 
-describe('3.x.x - lessThanOrEquals should work in functional style', () => {
+describe('3.x.x - lessThanOrEqualsFn should work in functional style', () => {
   it('should be a function', () => {
-    const actual = typeof lessThanOrEquals
+    const actual = typeof lessThanOrEqualsFn
     const expected = 'function'
 
     expect(actual).toEqual(expected)
   })
 
-  it('should perform lessThanOrEquals', () => {
+  it('should perform lessThanOrEqualsFn', () => {
     const data = {
       foo: 10
     }
 
-    const RULE = lessThanOrEquals('@foo', 10)
+    const RULE = lessThanOrEqualsFn('@foo', 10)
     const actual = RULE(data)
     const expected = true
 
@@ -21,30 +21,30 @@ describe('3.x.x - lessThanOrEquals should work in functional style', () => {
   })
 })
 
-describe('lessThanOrEqualsFn', () => {
-  it('lessThanOrEqualsFn should be a function', () => {
-    expect(typeof lessThanOrEqualsFn).toEqual('function')
+describe('lessThanOrEquals', () => {
+  it('lessThanOrEquals should be a function', () => {
+    expect(typeof lessThanOrEquals).toEqual('function')
   })
 
-  it('lessThanOrEqualsFn should return true if "left" is less than "right"', () => {
-    const actual = lessThanOrEqualsFn(4, 5)
+  it('lessThanOrEquals should return true if "left" is less than "right"', () => {
+    const actual = lessThanOrEquals(4, 5)
     const expected = true
     expect(actual).toEqual(expected)
   })
 
-  it('lessThanOrEqualsFn should return true if "left" equals "right"', () => {
-    const actual = lessThanOrEqualsFn(5, 5)
+  it('lessThanOrEquals should return true if "left" equals "right"', () => {
+    const actual = lessThanOrEquals(5, 5)
     const expected = true
     expect(actual).toEqual(expected)
   })
 
-  it('lessThanOrEqualsFn should return false if "left" is greater than "right', () => {
-    const actual = lessThanOrEqualsFn(255, 254)
+  it('lessThanOrEquals should return false if "left" is greater than "right', () => {
+    const actual = lessThanOrEquals(255, 254)
     const expected = false
     expect(actual).toEqual(expected)
   })
 
-  it('lessThanOrEqualsFn should return false if the key is a string that parses to NaN', () => {
+  it('lessThanOrEquals should return false if the key is a string that parses to NaN', () => {
     const redProps = [
       'cool',
       'some string',
@@ -54,21 +54,21 @@ describe('lessThanOrEqualsFn', () => {
       'true'
     ]
     redProps.forEach((val) => {
-      const actual = lessThanOrEqualsFn(val, 0)
+      const actual = lessThanOrEquals(val, 0)
       const expected = false
       expect(actual).toEqual(expected)
     })
   })
 
-  it('lessThanOrEqualsFn should compare strings based on standard lexicographical ordering, using Unicode values', () => {
-    expect(lessThanOrEqualsFn('a', 'b')).toEqual(true)
-    expect(lessThanOrEqualsFn('aaaa', 'abaa')).toEqual(true)
-    expect(lessThanOrEqualsFn('bb', 'a')).toEqual(false)
-    expect(lessThanOrEqualsFn('baa', 'abb')).toEqual(false)
-    expect(lessThanOrEqualsFn('1', 2)).toEqual(true)
-    expect(lessThanOrEqualsFn('2', 1)).toEqual(false)
-    expect(lessThanOrEqualsFn('2', '4')).toEqual(true)
-    expect(lessThanOrEqualsFn('4', '4')).toEqual(true)
-    expect(lessThanOrEqualsFn(4, '4')).toEqual(true)
+  it('lessThanOrEquals should compare strings based on standard lexicographical ordering, using Unicode values', () => {
+    expect(lessThanOrEquals('a', 'b')).toEqual(true)
+    expect(lessThanOrEquals('aaaa', 'abaa')).toEqual(true)
+    expect(lessThanOrEquals('bb', 'a')).toEqual(false)
+    expect(lessThanOrEquals('baa', 'abb')).toEqual(false)
+    expect(lessThanOrEquals('1', 2)).toEqual(true)
+    expect(lessThanOrEquals('2', 1)).toEqual(false)
+    expect(lessThanOrEquals('2', '4')).toEqual(true)
+    expect(lessThanOrEquals('4', '4')).toEqual(true)
+    expect(lessThanOrEquals(4, '4')).toEqual(true)
   })
 })

--- a/src/functions/less-than-equals.spec.js
+++ b/src/functions/less-than-equals.spec.js
@@ -71,4 +71,12 @@ describe('lessThanOrEquals', () => {
     expect(lessThanOrEquals('4', '4')).toEqual(true)
     expect(lessThanOrEquals(4, '4')).toEqual(true)
   })
+
+  it('when the toJson method is called it should return a json representation of the rule.', () => {
+    const MY_RULE = lessThanOrEqualsFn('@foo', 5)
+    const actual = MY_RULE.toJson()
+    const expected = JSON.stringify({ lessThanOrEquals: ['@foo', 5] })
+
+    expect(actual).toEqual(expected)
+  })
 })

--- a/src/functions/less-than.js
+++ b/src/functions/less-than.js
@@ -1,4 +1,4 @@
 import make from './make'
 
-export const lessThanFn = (left, right) => left < right
-export default make(lessThanFn)
+export const lessThan = (left, right) => left < right
+export default make(lessThan)

--- a/src/functions/less-than.spec.js
+++ b/src/functions/less-than.spec.js
@@ -75,4 +75,12 @@ describe('lessThan', () => {
     expect(lessThan('2', 1)).toEqual(false)
     expect(lessThan('2', '4')).toEqual(true)
   })
+
+  it('when the toJson method is called it should return a json representation of the rule.', () => {
+    const MY_RULE = lessThanFn('@foo', 5)
+    const actual = MY_RULE.toJson()
+    const expected = JSON.stringify({ lessThan: ['@foo', 5] })
+
+    expect(actual).toEqual(expected)
+  })
 })

--- a/src/functions/less-than.spec.js
+++ b/src/functions/less-than.spec.js
@@ -1,19 +1,19 @@
-import lessThan, { lessThanFn } from './less-than'
+import lessThanFn, { lessThan } from './less-than'
 
-describe('3.x.x - lessThan should work in functional style', () => {
+describe('3.x.x - lessThanFn should work in functional style', () => {
   it('should be a function', () => {
-    const actual = typeof lessThan
+    const actual = typeof lessThanFn
     const expected = 'function'
 
     expect(actual).toEqual(expected)
   })
 
-  it('should perform lessThan', () => {
+  it('should perform lessThanFn', () => {
     const data = {
       foo: 1
     }
 
-    const RULE = lessThan('@foo', 2)
+    const RULE = lessThanFn('@foo', 2)
     const actual = RULE(data)
     const expected = true
 
@@ -21,36 +21,36 @@ describe('3.x.x - lessThan should work in functional style', () => {
   })
 })
 
-describe('lessThanFn', () => {
-  it('lessThanFn should be a function', () => {
-    expect(typeof lessThanFn).toEqual('function')
+describe('lessThan', () => {
+  it('lessThan should be a function', () => {
+    expect(typeof lessThan).toEqual('function')
   })
 
-  it('lessThanFn should return true if "left" is less than "right"', () => {
-    const actual = lessThanFn(4, 5)
+  it('lessThan should return true if "left" is less than "right"', () => {
+    const actual = lessThan(4, 5)
     const expected = true
     expect(actual).toEqual(expected)
   })
 
-  it('lessThanFn should return false if "left" is greater than "right', () => {
-    const actual = lessThanFn(255, 254)
+  it('lessThan should return false if "left" is greater than "right', () => {
+    const actual = lessThan(255, 254)
     const expected = false
     expect(actual).toEqual(expected)
   })
 
-  it('lessThanFn should return false if "left" is equal to "right"', () => {
-    const actual = lessThanFn(123, 123)
+  it('lessThan should return false if "left" is equal to "right"', () => {
+    const actual = lessThan(123, 123)
     const expected = false
     expect(actual).toEqual(expected)
   })
 
-  it('lessThanFn should return false if the key is undefined', () => {
-    const actual = lessThanFn(undefined, 0)
+  it('lessThan should return false if the key is undefined', () => {
+    const actual = lessThan(undefined, 0)
     const expected = false
     expect(actual).toEqual(expected)
   })
 
-  it('lessThanFn should return false if the key is a string that parses to NaN', () => {
+  it('lessThan should return false if the key is a string that parses to NaN', () => {
     const redProps = [
       'cool',
       'some string',
@@ -60,19 +60,19 @@ describe('lessThanFn', () => {
       'true'
     ]
     redProps.forEach((val) => {
-      const actual = lessThanFn(val, 0)
+      const actual = lessThan(val, 0)
       const expected = false
       expect(actual).toEqual(expected, `should return false when passed ${val}`)
     })
   })
 
-  it('lessThanFn should compare strings based on standard lexicographical ordering, using Unicode values', () => {
-    expect(lessThanFn('a', 'b')).toEqual(true)
-    expect(lessThanFn('aaaa', 'abaa')).toEqual(true)
-    expect(lessThanFn('bb', 'a')).toEqual(false)
-    expect(lessThanFn('baa', 'abb')).toEqual(false)
-    expect(lessThanFn('1', 2)).toEqual(true)
-    expect(lessThanFn('2', 1)).toEqual(false)
-    expect(lessThanFn('2', '4')).toEqual(true)
+  it('lessThan should compare strings based on standard lexicographical ordering, using Unicode values', () => {
+    expect(lessThan('a', 'b')).toEqual(true)
+    expect(lessThan('aaaa', 'abaa')).toEqual(true)
+    expect(lessThan('bb', 'a')).toEqual(false)
+    expect(lessThan('baa', 'abb')).toEqual(false)
+    expect(lessThan('1', 2)).toEqual(true)
+    expect(lessThan('2', 1)).toEqual(false)
+    expect(lessThan('2', '4')).toEqual(true)
   })
 })

--- a/src/functions/make.js
+++ b/src/functions/make.js
@@ -5,7 +5,21 @@ export default (fn) => {
     throw new Error('make must be passed a function as argument 1')
   }
 
-  return (...args) =>
-    data =>
-      fn(...makeArgs(data, ...args), data)
+  if (typeof fn.name === 'undefined') {
+    throw new Error('the function passed to "make" must be a named function. It cannot be anonymous.')
+  }
+
+  return (...args) => {
+    const ruleJson = { [fn.name]: [] }
+
+    args.forEach((arg) => {
+      ruleJson[fn.name].push(arg)
+    })
+
+    const ruleFn = data => fn(...makeArgs(data, ...args), data)
+
+    ruleFn.toJson = () => JSON.stringify(ruleJson)
+
+    return ruleFn
+  }
 }

--- a/src/functions/make.js
+++ b/src/functions/make.js
@@ -5,7 +5,7 @@ export default (fn) => {
     throw new Error('make must be passed a function as argument 1')
   }
 
-  if (typeof fn.name === 'undefined') {
+  if (!fn.name) {
     throw new Error('the function passed to "make" must be a named function. It cannot be anonymous.')
   }
 

--- a/src/functions/make.spec.js
+++ b/src/functions/make.spec.js
@@ -24,4 +24,25 @@ describe('make', () => {
   it('it should throw an error if what is passed in is not a function', () => {
     expect(() => make('hello')).toThrow('make must be passed a function as argument 1')
   })
+
+  it('should attach a toJson method that can be used to get the JSON version of the rule definition.', () => {
+    const threeEqual = make(function threeEqual (a, b, c) {
+      return a === b && b === c
+    })
+
+    const data = {
+      foo: 'same',
+      bar: 'same',
+      baz: 'same'
+    }
+
+    const MY_RULE = threeEqual('@foo', '@bar', '@baz')
+
+    expect(MY_RULE(data)).toEqual(true)
+
+    const actual = MY_RULE.toJson()
+    const expected = JSON.stringify({ threeEqual: ['@foo', '@bar', '@baz'] })
+
+    expect(actual).toEqual(expected)
+  })
 })

--- a/src/functions/make.spec.js
+++ b/src/functions/make.spec.js
@@ -21,8 +21,12 @@ describe('make', () => {
     expect(actual).toEqual(expected)
   })
 
-  it('it should throw an error if what is passed in is not a function', () => {
+  it('should throw an error if what is passed in is not a function', () => {
     expect(() => make('hello')).toThrow('make must be passed a function as argument 1')
+  })
+
+  it('should throw an error if an anonymous function is passed', () => {
+    expect(() => make(() => {})).toThrow('the function passed to "make" must be a named function. It cannot be anonymous.')
   })
 
   it('should attach a toJson method that can be used to get the JSON version of the rule definition.', () => {

--- a/src/functions/none.js
+++ b/src/functions/none.js
@@ -1,10 +1,13 @@
 import or from './or'
 import isRule from '../private/is-rule'
+import attachToJson from '../private/attach-to-json'
 
 export default (...rules) => {
   if (!rules.every(x => isRule(x))) {
     throw new Error('Regent: none requires all arguments to be a function')
   }
 
-  return data => !or(...rules)(data)
+  return attachToJson(function none (data) {
+    return !or(...rules)(data)
+  }, rules)
 }

--- a/src/functions/none.spec.js
+++ b/src/functions/none.spec.js
@@ -49,4 +49,21 @@ describe('none', () => {
 
     expect(() => none(RULE_A, NOT_RULE)(data)).toThrow('Regent: none requires all arguments to be a function')
   })
+
+  it('when the toJson method is called it should return a json representation of the rule.', () => {
+    const A = equals('@foo', 'a')
+    const B = equals('@bar', 'b')
+
+    const MY_RULE = none(A, B)
+
+    const actual = MY_RULE.toJson()
+    const expected = JSON.stringify({
+      none: [
+        { equals: ['@foo', 'a'] },
+        { equals: ['@bar', 'b'] }
+      ]
+    })
+
+    expect(actual).toEqual(expected)
+  })
 })

--- a/src/functions/not.js
+++ b/src/functions/not.js
@@ -1,10 +1,13 @@
 import isRule from '../private/is-rule'
 import evaluateRule from '../private/evaluate-rule'
+import attachToJson from '../private/attach-to-json'
 
 export default (rule) => {
   if (!isRule(rule)) {
     throw new Error('Regent: not requires the first argument to be a function')
   }
 
-  return data => !evaluateRule(rule, data)
+  return attachToJson(function not (data) {
+    return !evaluateRule(rule, data)
+  }, [rule])
 }

--- a/src/functions/not.spec.js
+++ b/src/functions/not.spec.js
@@ -45,4 +45,19 @@ describe('not', () => {
   it('should throw if not passed a rule', () => {
     expect(() => not('string')).toThrow('Regent: not requires the first argument to be a function')
   })
+
+  it('when the toJson method is called it should return a json representation of the rule.', () => {
+    const A = equals('@foo', 'a')
+
+    const MY_RULE = not(A)
+
+    const actual = MY_RULE.toJson()
+    const expected = JSON.stringify({
+      not: [
+        { equals: ['@foo', 'a'] }
+      ]
+    })
+
+    expect(actual).toEqual(expected)
+  })
 })

--- a/src/functions/or.js
+++ b/src/functions/or.js
@@ -1,5 +1,6 @@
 import isRule from '../private/is-rule'
 import evaluateRule from '../private/evaluate-rule'
+import attachToJson from '../private/attach-to-json'
 
 export default (...rules) => {
   // throw if one or more of the rules are
@@ -8,5 +9,7 @@ export default (...rules) => {
     throw new Error('Regent: or requires all arguments to be a function')
   }
 
-  return data => rules.some(x => evaluateRule(x, data))
+  return attachToJson(function or (data) {
+    return rules.some(x => evaluateRule(x, data))
+  }, rules)
 }

--- a/src/functions/or.spec.js
+++ b/src/functions/or.spec.js
@@ -61,4 +61,21 @@ describe('or', () => {
 
     expect(() => or(A, B)(data)).toThrow('Regent: or requires all arguments to be a function')
   })
+
+  it('when the toJson method is called it should return a json representation of the rule.', () => {
+    const A = equals('@foo', 'a')
+    const B = equals('@bar', 'b')
+
+    const MY_RULE = or(A, B)
+
+    const actual = MY_RULE.toJson()
+    const expected = JSON.stringify({
+      or: [
+        { equals: ['@foo', 'a'] },
+        { equals: ['@bar', 'b'] }
+      ]
+    })
+
+    expect(actual).toEqual(expected)
+  })
 })

--- a/src/functions/regex.js
+++ b/src/functions/regex.js
@@ -1,4 +1,4 @@
 import make from './make'
 
-export const regexFn = (left, right) => right.test(left)
-export default make(regexFn)
+export const regex = (left, right) => right.test(left)
+export default make(regex)

--- a/src/functions/regex.spec.js
+++ b/src/functions/regex.spec.js
@@ -58,4 +58,13 @@ describe('regex', () => {
     expect(regex('baz123', /[a-z]+[0-9]+/)).toEqual(true)
     expect(regex('123baz', /[a-z]+[0-9]+/)).toEqual(false)
   })
+
+  it('when the toJson method is called it should return a json representation of the rule.', () => {
+    const MY_RULE = regexFn('@foo', 'a')
+
+    const actual = MY_RULE.toJson()
+    const expected = JSON.stringify({ regex: ['@foo', 'a'] })
+
+    expect(actual).toEqual(expected)
+  })
 })

--- a/src/functions/regex.spec.js
+++ b/src/functions/regex.spec.js
@@ -1,19 +1,19 @@
-import regex, { regexFn } from './regex'
+import regexFn, { regex } from './regex'
 
-describe('3.x.x - regex should work in functional style', () => {
+describe('3.x.x - regexFn should work in functional style', () => {
   it('should be a function', () => {
-    const actual = typeof regex
+    const actual = typeof regexFn
     const expected = 'function'
 
     expect(actual).toEqual(expected)
   })
 
-  it('should perform regex', () => {
+  it('should perform regexFn', () => {
     const data = {
       foo: 'hello'
     }
 
-    const RULE = regex('@foo', /^hello/)
+    const RULE = regexFn('@foo', /^hello/)
     const actual = RULE(data)
     const expected = true
 
@@ -21,41 +21,41 @@ describe('3.x.x - regex should work in functional style', () => {
   })
 })
 
-describe('regexFn', () => {
-  it('regexFn should be a function', () => {
-    expect(typeof regexFn).toEqual('function')
+describe('regex', () => {
+  it('regex should be a function', () => {
+    expect(typeof regex).toEqual('function')
   })
 
-  it('regexFn should return true if the left matches the regexFn provided in the right', () => {
+  it('regex should return true if the left matches the regex provided in the right', () => {
     const left = 'hello'
     const right = /^hello/
-    const actual = regexFn(left, right)
+    const actual = regex(left, right)
     const expected = true
 
     expect(actual).toEqual(expected)
   })
 
-  it('regexFn should return true if the left matches the regexFn provided in the right', () => {
+  it('regex should return true if the left matches the regex provided in the right', () => {
     const left = '12hello45'
     const right = /[a-z]+/
-    const actual = regexFn(left, right)
+    const actual = regex(left, right)
     const expected = true
 
     expect(actual).toEqual(expected)
   })
 
-  it('regexFn should return false if there is no match', () => {
+  it('regex should return false if there is no match', () => {
     const left = '12hello45'
     const right = /[A-Z]+/
-    const actual = regexFn(left, right)
+    const actual = regex(left, right)
     const expected = false
 
     expect(actual).toEqual(expected)
   })
 
-  it('regexFn should pass documentation examples', () => {
-    expect(regexFn('hello world', /world/)).toEqual(true)
-    expect(regexFn('baz123', /[a-z]+[0-9]+/)).toEqual(true)
-    expect(regexFn('123baz', /[a-z]+[0-9]+/)).toEqual(false)
+  it('regex should pass documentation examples', () => {
+    expect(regex('hello world', /world/)).toEqual(true)
+    expect(regex('baz123', /[a-z]+[0-9]+/)).toEqual(true)
+    expect(regex('123baz', /[a-z]+[0-9]+/)).toEqual(false)
   })
 })

--- a/src/functions/some.js
+++ b/src/functions/some.js
@@ -2,7 +2,7 @@ import isRule from '../private/is-rule'
 import evaluateRule from '../private/evaluate-rule'
 import makeWithContext from '../private/make-with-context'
 
-export const someFn = (left, right, context = '__', data) => {
+export const some = (left, right, context = '__', data) => {
   if (!isRule(right)) {
     throw new Error('Regent: the right property of an every rule must be a regent rule')
   }
@@ -14,4 +14,4 @@ export const someFn = (left, right, context = '__', data) => {
   return left.some(x => evaluateRule(right, { ...data, [context]: x }))
 }
 
-export default makeWithContext(someFn)
+export default makeWithContext(some)

--- a/src/functions/some.spec.js
+++ b/src/functions/some.spec.js
@@ -1,8 +1,8 @@
-import some, { someFn } from './some'
+import someFn, { some } from './some'
 import equals from '../functions/equals'
 import or from '../functions/or'
 
-describe('3.x.x - some', () => {
+describe('3.x.x - someFn', () => {
   it('should work with function style rules (passing)', () => {
     const data = {
       nodes: [
@@ -12,7 +12,7 @@ describe('3.x.x - some', () => {
     }
 
     const RULE = equals('@__.foo', 'bar')
-    const E_RULE = some('@nodes', RULE)
+    const E_RULE = someFn('@nodes', RULE)
     const actual = E_RULE(data)
     const expected = true
 
@@ -28,7 +28,7 @@ describe('3.x.x - some', () => {
     }
 
     const RULE = equals('@this.foo', 'bar')
-    const E_RULE = some('@nodes', RULE, 'this')
+    const E_RULE = someFn('@nodes', RULE, 'this')
     const actual = E_RULE(data)
     const expected = true
 
@@ -44,7 +44,7 @@ describe('3.x.x - some', () => {
     }
 
     const RULE = equals('@__.foo', 'bar')
-    const E_RULE = some('@nodes', RULE)
+    const E_RULE = someFn('@nodes', RULE)
     const actual = E_RULE(data)
     const expected = false
 
@@ -60,7 +60,7 @@ describe('3.x.x - some', () => {
     }
 
     const RULE = true
-    const E_RULE = some('@nodes', RULE)
+    const E_RULE = someFn('@nodes', RULE)
     const actual = E_RULE(data)
     const expected = true
 
@@ -76,7 +76,7 @@ describe('3.x.x - some', () => {
     }
 
     const RULE = false
-    const E_RULE = some('@nodes', RULE)
+    const E_RULE = someFn('@nodes', RULE)
     const actual = E_RULE(data)
     const expected = false
 
@@ -84,74 +84,74 @@ describe('3.x.x - some', () => {
   })
 })
 
-describe('someFn', () => {
-  it('someFn should be a function', () => {
-    const actual = typeof someFn
+describe('some', () => {
+  it('some should be a function', () => {
+    const actual = typeof some
     const expected = 'function'
     expect(actual).toEqual(expected)
   })
 
-  it('someFn should evaluate a regent rule for each item in the looked up array. Should return true if someFn are true', () => {
+  it('some should evaluate a regent rule for each item in the looked up array. Should return true if some are true', () => {
     const left = [
       { value: false },
       { value: false },
       { value: true }
     ]
     const right = equals('@__.value', true)
-    const actual = someFn(left, right)
+    const actual = some(left, right)
     const expected = true
     expect(actual).toEqual(expected)
   })
 
-  it('someFn should evaluate a regent rule for each item in the looked up array. Should return false if none are true', () => {
+  it('some should evaluate a regent rule for each item in the looked up array. Should return false if none are true', () => {
     const left = [
       { value: false },
       { value: false },
       { value: false }
     ]
     const right = equals('@__.value', true)
-    const actual = someFn(left, right)
+    const actual = some(left, right)
     const expected = false
     expect(actual).toEqual(expected)
   })
 
-  it('someFn should throw an error if right is not a regent rule', () => {
+  it('some should throw an error if right is not a regent rule', () => {
     const left = [
       { value: true },
       { value: true },
       { value: true }
     ]
     const right = { this_is_not: 'a rule' }
-    expect(() => someFn(left, right)).toThrow('Regent: the right property of an every rule must be a regent rule')
+    expect(() => some(left, right)).toThrow('Regent: the right property of an every rule must be a regent rule')
   })
 
-  it('someFn should return false if left is not an array', () => {
+  it('some should return false if left is not an array', () => {
     let left = {
       not: 'an array'
     }
     let right = equals('@__.value', true)
-    let actual = someFn(left, right)
+    let actual = some(left, right)
     expect(actual).toEqual(false)
 
     left = 42
     right = equals('@__.value', true)
-    actual = someFn(left, right)
+    actual = some(left, right)
     expect(actual).toEqual(false)
 
     left = 'I am clearly a string'
     right = equals('@__.value', true)
-    actual = someFn(left, right)
+    actual = some(left, right)
     expect(actual).toEqual(false)
   })
 
-  it('someFn should return false if left is undefined', () => {
+  it('some should return false if left is undefined', () => {
     const right = equals('@__.value', true)
-    const actual = someFn(undefined, right)
+    const actual = some(undefined, right)
     const expected = false
     expect(actual).toEqual(expected)
   })
 
-  it('someFn should work with helper composed rules', () => {
+  it('some should work with helper composed rules', () => {
     const left = [
       { value: true },
       { value: 'yes' },
@@ -161,13 +161,13 @@ describe('someFn', () => {
       equals('@__.value', true),
       equals('@__.value', 'yes')
     )
-    const actual = someFn(left, right)
+    const actual = some(left, right)
     expect(actual).toEqual(true)
   })
 
   it('should return false if the first argument is not an array', () => {
     const RULE = equals('string', 'bar')
-    const actual = someFn('@nodes', RULE)
+    const actual = some('@nodes', RULE)
     const expected = false
 
     expect(actual).toEqual(expected)

--- a/src/functions/some.spec.js
+++ b/src/functions/some.spec.js
@@ -172,4 +172,17 @@ describe('some', () => {
 
     expect(actual).toEqual(expected)
   })
+
+  it('when it\'s toJson method is called it should return a json representation of the rule', () => {
+    const RULE = equals('@__.foo', 'bar')
+    const E_RULE = someFn('@nodes', RULE)
+    const actual = E_RULE.toJson()
+    const expected = JSON.stringify({
+      some: ['@nodes',
+        { equals: ['@__.foo', 'bar'] }
+      ]
+    })
+
+    expect(actual).toEqual(expected)
+  })
 })

--- a/src/functions/type-of.js
+++ b/src/functions/type-of.js
@@ -1,4 +1,4 @@
 import make from './make'
 
-export const typeOfFn = (left, right) => typeof left === right; // eslint-disable-line
-export default make(typeOfFn)
+export const typeOf = (left, right) => typeof left === right; // eslint-disable-line
+export default make(typeOf)

--- a/src/functions/type-of.spec.js
+++ b/src/functions/type-of.spec.js
@@ -1,19 +1,19 @@
-import typeOf, { typeOfFn } from './type-of'
+import typeOfFn, { typeOf } from './type-of'
 
-describe('3.x.x - typeOf should work in functional style', () => {
+describe('3.x.x - typeOfFn should work in functional style', () => {
   it('should be a function', () => {
-    const actual = typeof typeOf
+    const actual = typeof typeOfFn
     const expected = 'function'
 
     expect(actual).toEqual(expected)
   })
 
-  it('should perform typeOf', () => {
+  it('should perform typeOfFn', () => {
     const data = {
       foo: () => {}
     }
 
-    const RULE = typeOf('@foo', 'function')
+    const RULE = typeOfFn('@foo', 'function')
     const actual = RULE(data)
     const expected = true
 
@@ -21,32 +21,40 @@ describe('3.x.x - typeOf should work in functional style', () => {
   })
 })
 
-describe('typeOfFn', () => {
-  it('typeOfFn should be a function', () => {
-    expect(typeof typeOfFn).toEqual('function')
+describe('typeOf', () => {
+  it('typeOf should be a function', () => {
+    expect(typeof typeOf).toEqual('function')
   })
 
-  it('typeOfFn should return true if typeOfFn left is equal to right', () => {
+  it('typeOf should return true if typeOf left is equal to right', () => {
     const left = 'hello'
     const right = 'string'
-    const actual = typeOfFn(left, right)
+    const actual = typeOf(left, right)
     const expected = true
     expect(actual).toEqual(expected)
   })
 
-  it('typeOfFn should return false if typeOfFn left is not equal to right', () => {
+  it('typeOf should return false if typeOf left is not equal to right', () => {
     const left = { a: 'b' }
     const right = 'string'
-    const actual = typeOfFn(left, right)
+    const actual = typeOf(left, right)
     const expected = false
     expect(actual).toEqual(expected)
   })
 
-  it('typeOfFn should handle undefined', () => {
+  it('typeOf should handle undefined', () => {
     const left = undefined
     const right = undefined
-    const actual = typeOfFn(left, right)
+    const actual = typeOf(left, right)
     const expected = false
+    expect(actual).toEqual(expected)
+  })
+
+  it('when the toJson method is called it should return a json representation of the rule.', () => {
+    const MY_RULE = typeOfFn('@foo', 5)
+    const actual = MY_RULE.toJson()
+    const expected = JSON.stringify({ typeOf: ['@foo', 5] })
+
     expect(actual).toEqual(expected)
   })
 })

--- a/src/functions/xor.js
+++ b/src/functions/xor.js
@@ -1,17 +1,18 @@
 import isRule from '../private/is-rule'
 import evaluateRule from '../private/evaluate-rule'
+import attachToJson from '../private/attach-to-json'
 
-export default (...rules) =>
-  (data) => {
+export default (...rules) => {
   // throw if one or more of the rules are
   // not rules
-    if (!rules.every(x => isRule(x))) {
-      throw new Error('Regent: xor requires all arguments to be a function')
-    }
-
-    if (rules.length !== 2) {
-      throw Error('Regent: xor must take exactly 2 rules')
-    }
-
-    return (evaluateRule(rules[0], data) || evaluateRule(rules[1], data)) && !(evaluateRule(rules[0], data) && evaluateRule(rules[1], data))
+  if (!rules.every(x => isRule(x))) {
+    throw new Error('Regent: xor requires all arguments to be a function')
   }
+
+  if (rules.length !== 2) {
+    throw Error('Regent: xor must take exactly 2 rules')
+  }
+  return attachToJson(function xor (data) {
+    return (evaluateRule(rules[0], data) || evaluateRule(rules[1], data)) && !(evaluateRule(rules[0], data) && evaluateRule(rules[1], data))
+  }, rules)
+}

--- a/src/private/attach-to-json.js
+++ b/src/private/attach-to-json.js
@@ -1,0 +1,11 @@
+export default function attachToJson (fn, rules) {
+  const ruleJson = { [fn.name]: [] }
+
+  rules.forEach((rule) => {
+    ruleJson[fn.name].push(JSON.parse(rule.toJson()))
+  })
+
+  fn.toJson = () => JSON.stringify(ruleJson)
+
+  return fn
+}

--- a/src/private/attach-to-json.js
+++ b/src/private/attach-to-json.js
@@ -2,7 +2,11 @@ export default function attachToJson (fn, rules) {
   const ruleJson = { [fn.name]: [] }
 
   rules.forEach((rule) => {
-    ruleJson[fn.name].push(JSON.parse(rule.toJson()))
+    if (typeof rule === 'boolean') {
+      ruleJson[fn.name].push(rule)
+    } else {
+      ruleJson[fn.name].push(JSON.parse(rule.toJson()))
+    }
   })
 
   fn.toJson = () => JSON.stringify(ruleJson)

--- a/src/private/attach-to-json.spec.js
+++ b/src/private/attach-to-json.spec.js
@@ -1,0 +1,74 @@
+import attachToJson from './attach-to-json'
+import equals from '../functions/equals'
+
+describe('attachToJson', () => {
+  it('should be a function', async () => {
+    expect(typeof attachToJson).toEqual('function')
+  })
+
+  it('should should add a toJson method to the passed in composition function.', async () => {
+    const A = equals('@foo', 'a')
+    const B = equals('@bar', 'a')
+
+    const data = {
+      foo: 'a',
+      bar: 'a'
+    }
+
+    function novelAndFn (a, b) {
+      return attachToJson(function novelAnd (data) {
+        return a(data) && b(data)
+      }, [a, b])
+    }
+
+    const MY_RULE = novelAndFn(A, B)
+
+    expect(MY_RULE(data)).toEqual(true)
+
+    const actual = MY_RULE.toJson()
+    const expected = JSON.stringify({
+      novelAnd: [
+        { equals: ['@foo', 'a'] },
+        { equals: ['@bar', 'a'] }
+      ]
+    })
+
+    expect(expected).toEqual(actual)
+  })
+
+  it('should should return a json string with nested compositions.', async () => {
+    const A = equals('@foo', 'a')
+    const B = equals('@bar', 'b')
+
+    function novelAndFn (a, b) {
+      return attachToJson(function novelAnd (data) {
+        return a(data) && b(data)
+      }, [a, b])
+    }
+
+    const RULE_ONE = novelAndFn(A, B)
+    const RULE_TWO = novelAndFn(A, A)
+
+    const COMP = novelAndFn(RULE_ONE, RULE_TWO)
+
+    const actual = COMP.toJson()
+    const expected = JSON.stringify({
+      novelAnd: [
+        {
+          novelAnd: [
+            { equals: ['@foo', 'a'] },
+            { equals: ['@bar', 'b'] }
+          ]
+        },
+        {
+          novelAnd: [
+            { equals: ['@foo', 'a'] },
+            { equals: ['@foo', 'a'] }
+          ]
+        }
+      ]
+    })
+
+    expect(expected).toEqual(actual)
+  })
+})

--- a/src/private/attach-to-json.spec.js
+++ b/src/private/attach-to-json.spec.js
@@ -36,6 +36,35 @@ describe('attachToJson', () => {
     expect(expected).toEqual(actual)
   })
 
+  it('should should handle booleans in composition functions.', async () => {
+    const A = equals('@foo', 'a')
+    const B = true
+
+    const data = {
+      foo: 'a'
+    }
+
+    function novelAndFn (a, b) {
+      return attachToJson(function novelAnd (data) {
+        return a(data) && b
+      }, [a, b])
+    }
+
+    const MY_RULE = novelAndFn(A, B)
+
+    expect(MY_RULE(data)).toEqual(true)
+
+    const actual = MY_RULE.toJson()
+    const expected = JSON.stringify({
+      novelAnd: [
+        { equals: ['@foo', 'a'] },
+        true
+      ]
+    })
+
+    expect(expected).toEqual(actual)
+  })
+
   it('should should return a json string with nested compositions.', async () => {
     const A = equals('@foo', 'a')
     const B = equals('@bar', 'b')

--- a/src/private/make-with-context.js
+++ b/src/private/make-with-context.js
@@ -5,7 +5,22 @@ export default (fn) => {
     throw new Error('makeWithContext must be passed a function as argument 1')
   }
 
-  return (left, right, context = '__') =>
-    data =>
+  return (left, right, context = '__') => {
+    const ruleFn = data =>
       fn(...makeArgs(data, left, right), context, data)
+
+    ruleFn.toJson = () => {
+      let ruleJson
+
+      if (typeof right === 'boolean') {
+        ruleJson = { [fn.name]: [left, right] }
+      } else {
+        ruleJson = { [fn.name]: [left, JSON.parse(right.toJson())] }
+      }
+
+      return JSON.stringify(ruleJson)
+    }
+
+    return ruleFn
+  }
 }

--- a/src/private/make-with-context.spec.js
+++ b/src/private/make-with-context.spec.js
@@ -53,4 +53,13 @@ describe('makeWithContext', () => {
 
     expect(actual).toEqual(expected)
   })
+
+  it('should correctly render booleans to JSON', () => {
+    const FN = (arg1, arg2) => `${arg1}: ${arg2}`
+    const returnFn = makeWithContext(FN)('@foo.bar', true)
+    const actual = returnFn.toJson()
+    const expected = '{"FN":["@foo.bar",true]}'
+
+    expect(actual).toEqual(expected)
+  })
 })

--- a/src/regent.spec.js
+++ b/src/regent.spec.js
@@ -52,4 +52,50 @@ describe('regent', () => {
     const expected = true
     expect(actual).toEqual(expected)
   })
+
+  it('should be able to export a large complicated composition to json.', () => {
+    const isRaining = equals('@isRaining', true)
+    const isCalm = lessThan('@windSpeedInMph', 25)
+    const isRainingAndCalm = and(isRaining, isCalm)
+    const isWindy = greaterThanOrEquals('@windSpeedInMph', 25)
+    const isWindyOrCalmAndRaining = or(isWindy, isRainingAndCalm)
+    const sunny = regex('@__description', /sunny/)
+    const weekHasSunshine = some('@days', sunny)
+    const imHappy = or(not(isRaining), isRainingAndCalm, and(isWindyOrCalmAndRaining, weekHasSunshine))
+
+    const actual = imHappy.toJson()
+    const expected = JSON.stringify({
+      or: [
+        { not: [{ equals: ['@isRaining', true] }] },
+        {
+          and: [
+            { equals: ['@isRaining', true] },
+            { lessThan: ['@windSpeedInMph', 25] }
+          ]
+        },
+        {
+          and: [
+            {
+              or: [
+                { greaterThanOrEquals: ['@windSpeedInMph', 25] },
+                {
+                  and: [
+                    { equals: ['@isRaining', true] },
+                    { lessThan: ['@windSpeedInMph', 25] }
+                  ]
+                }
+              ]
+            },
+            {
+              some: ['@days',
+                { regex: ['@__description', {}] }
+              ]
+            }
+          ]
+        }
+      ]
+    })
+
+    expect(actual).toEqual(expected)
+  })
 })


### PR DESCRIPTION
Implemented the following interface for exporting rules:

```javascript
const isRaining = equals('@isRaining', true);
const isCalm = lessThan('@windSpeedInMph', 25);
const isRainingAndCalm = and(isRaining, isCalm);

const isRainingJson = isRaining.toJson()
// { "equals": ["isRaining", true] }

const isRainingAndCalmJson = isRainingAndCalm.toJson()
// {
//   "and": [
//     { "equals": ["@isRaining", true] },
//     { "lessThan": ["@windSpeedInMph", 25] }
//   ]
// }
```