### PR TITLE
WIP: Implemented the 'lookups' function and added documentation for it.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -872,6 +872,37 @@ const {
 } = parseFn(json)
 ```
 
+## lookups
+
+`lookups(RegentRule)`
+
+The `lookups` function accepts a RegentRule and returns an array of the lookups referenced by that rule. The RegentRule provided can be arbitrarily complex.
+
+_*Arguments*_
+
+* `RegentRule (Plain Object)`
+
+_*Returns*_
+
+`Array`: an array containing all the lookups present in the provided rule.
+
+_*Example*_
+
+```javascript
+import { equals, lessThan, lookups } from 'regent';
+
+const isRaining = equals('@weather.precipitation', true);
+const isCalm = lessThan('@weather.wind.speed', 25);
+const isRainingAndCalm = and(isRaining, isCalm);
+
+const paths = lookups(isRainingAndCalm);
+
+// [
+//   '@weather.precipitation',
+//   '@weather.wind.speed',
+// ]
+```
+
 ## Utilities
 
 ### toJson

--- a/src/functions/lookups.js
+++ b/src/functions/lookups.js
@@ -1,0 +1,38 @@
+function fields (rule) {
+  const lookups = []
+
+  function collectLookups (value) {
+    if (typeof value === 'string' && value.charAt(0) === '@') {
+      lookups.push(value)
+    }
+  };
+
+  function walk (rule) {
+    collectLookups(rule)
+    let args
+
+    if (typeof rule !== 'string' && rule.length) {
+      args = rule
+    }
+
+    if (typeof rule === 'object') {
+      args = Object.keys(rule).map((k) => rule[k])
+    }
+
+    if (args && args.length > 0) {
+      args.forEach((arg) => {
+        walk(arg)
+      })
+    }
+  };
+
+  if (rule.toJson) {
+    walk(JSON.parse(rule.toJson()))
+  } else {
+    walk(JSON.parse(rule))
+  }
+
+  return lookups
+}
+
+export default fields

--- a/src/functions/lookups.spec.js
+++ b/src/functions/lookups.spec.js
@@ -1,0 +1,57 @@
+import lookups from './lookups'
+import equals from './equals'
+import and from './and'
+import not from './not'
+import some from './some'
+
+describe('lookups', () => {
+  it('should be a function', () => {
+    const actual = typeof lookups
+    const expected = 'function'
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should get the field from a single rule.', () => {
+    const foo = equals('@path.to.foo', 'foo')
+    const expected = ['@path.to.foo']
+    const actual = lookups(foo)
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should get the lookups from a rule composition', () => {
+    const foo = equals('@path.to.foo', 'foo')
+    const bar = equals('@path.to.bar', 'bar')
+    const expected = ['@path.to.foo', '@path.to.bar']
+    const actual = lookups(and(foo, bar))
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should get the lookups from a rule when there is more than one lookup', () => {
+    const fooBar = equals('@path.to.foo', '@path.to.bar')
+    const expected = ['@path.to.foo', '@path.to.bar']
+    const actual = lookups(fooBar)
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should get the lookups from a rule composition where each rule contains more than one lookup', () => {
+    const fooBar = equals('@path.to.foo', '@path.to.bar')
+    const goo = equals('@some.path.to.goo', 'goo')
+    const expected = ['@path.to.foo', '@path.to.bar', '@some.path.to.goo']
+    const actual = lookups(and(fooBar, not(goo)))
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should get the lookups from a contextual rule', () => {
+    const fooBar = equals('@__.path.to.foo')
+
+    const expected = ['@path.to.array', '@__.path.to.foo']
+    const actual = lookups(some('@path.to.array', fooBar))
+
+    expect(actual).toEqual(expected)
+  })
+})


### PR DESCRIPTION
The `lookups` function accepts a RegentRule and returns an array of the lookups referenced by that rule. The RegentRule provided can be arbitrarily complex.

_*Arguments*_

* `RegentRule (Plain Object)`

_*Returns*_

`Array`: an array containing all the lookups present in the provided rule.

_*Example*_

```javascript
import { equals, lessThan, lookups } from 'regent';

const isRaining = equals('@weather.precipitation', true);
const isCalm = lessThan('@weather.wind.speed', 25);
const isRainingAndCalm = and(isRaining, isCalm);

const paths = lookups(isRainingAndCalm);

// [
//   '@weather.precipitation',
//   '@weather.wind.speed',
// ]
```