### PR TITLE
Make strip-at function handle null and undefined values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regent",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regent",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "Javascript rules engine",
   "repository": {
     "type": "git",

--- a/src/private/make-args.spec.js
+++ b/src/private/make-args.spec.js
@@ -108,4 +108,23 @@ describe('makeArgs', () => {
     const expected = ['bar', 'a', 'b']
     expect(actual).toEqual(expected)
   })
+
+  it('should not die when passed null', () => {
+    const data = {
+      foo: [
+        { bar: 'bar' }
+      ],
+      biz: 'a',
+      baz: 'b'
+    }
+
+    const args = [
+      '@foo[0].bar',
+      null
+    ]
+
+    const actual = makeArgs(data, ...args)
+    const expected = ['bar', null]
+    expect(actual).toEqual(expected)
+  })
 })

--- a/src/private/strip-at.js
+++ b/src/private/strip-at.js
@@ -1,5 +1,5 @@
 export default function stripAt (arg) {
-  return arg[0] === '@'
+  return arg && arg[0] === '@'
     ? arg.slice(1)
     : arg
 }

--- a/src/private/strip-at.spec.js
+++ b/src/private/strip-at.spec.js
@@ -34,4 +34,11 @@ describe('stripAt', () => {
 
     expect(actual).toEqual(expected)
   })
+
+  it('should handle null', () => {
+    const actual = stripAt(null)
+    const expected = null
+
+    expect(actual).toEqual(expected)
+  })
 })

--- a/src/private/strip-at.spec.js
+++ b/src/private/strip-at.spec.js
@@ -41,4 +41,25 @@ describe('stripAt', () => {
 
     expect(actual).toEqual(expected)
   })
+
+  it('should handle undefined', () => {
+    const actual = stripAt(undefined)
+    const expected = undefined
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should handle empty array', () => {
+    const actual = stripAt([])
+    const expected = []
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should handle empty Object', () => {
+    const actual = stripAt({})
+    const expected = {}
+
+    expect(actual).toEqual(expected)
+  })
 })


### PR DESCRIPTION
Identified a bug that caused the `strip-at` function to throw an error if it was passed `null` or `undefined`.

Adds a check to allow strip-at to work with null and undefined.
Adds tests to confirm functionality.