### PR TITLE
docs: corrected the import syntax in the example code for filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ isRainingAndCalm(data); // true
 Regent also provides a simple way to find or filter array items based on a regent rule.
 
 ```javascript
-{ equals, lessThan, find, filter } from 'regent';
+import { equals, lessThan, find, filter } from 'regent';
 
 const isRaining = equals('@isRaining', true);
 const isSunny = lessThan('@cloudCover', 10);


### PR DESCRIPTION
This is a trivial change, but we all love docs with copy/paste-able code!  
If there are any contribution guidelines that I missed, please let me know.