### PR TITLE
Add support for regex in json output

### DIFF
--- a/src/functions/regex.spec.ts
+++ b/src/functions/regex.spec.ts
@@ -60,10 +60,11 @@ describe('regex', () => {
   })
 
   it('when the toJson method is called it should return a json representation of the rule.', () => {
-    const MY_RULE = regexFn('@foo', 'a')
+    const MY_REGEX = /[a-z]+[0-9]+/g
+    const MY_RULE = regexFn('@foo', MY_REGEX)
 
     const actual = MY_RULE.toJson()
-    const expected = JSON.stringify({ regex: ['@foo', 'a'] })
+    const expected = JSON.stringify({ regex: ['@foo', '/[a-z]+[0-9]+/g'] })
 
     expect(actual).toEqual(expected)
   })

--- a/src/private/serialize.ts
+++ b/src/private/serialize.ts
@@ -18,6 +18,8 @@ export default function serialize (data: any, args: any[], name: string): string
       json[name].push(JSON.parse(arg.toJson(data)))
     } else if (isOpticOrRule(arg)) {
       json[name].push(JSON.parse(arg.toJson()))
+    } else if (name === 'regex' && i === 1) {
+      json[name].push(arg.toString())
     } else {
       json[name].push(arg)
     }

--- a/src/regent.spec.ts
+++ b/src/regent.spec.ts
@@ -89,7 +89,7 @@ describe('regent', () => {
             },
             {
               some: ['@days',
-                { regex: ['@__description', {}] }
+                { regex: ['@__description', '/sunny/'] }
               ]
             }
           ]


### PR DESCRIPTION
### The Problem
The rule toJson method returns an empty object for regular expressions instead of information about the regular expression.

### The Fix
Use the RegExp toString function to get a string format of the regular expression.